### PR TITLE
feat: Add event in SwapAndBridge

### DIFF
--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -53,6 +53,16 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         bytes message;
     }
 
+    event SwapBeforeBridge(
+        address exchange,
+        address indexed swapToken,
+        address indexed acrossInputToken,
+        uint256 swapTokenAmount,
+        uint256 acrossInputAmount,
+        address indexed acrossOutputToken,
+        uint256 acrossOutputAmount
+    );
+
     /****************************************
      *                ERRORS                *
      ****************************************/
@@ -138,6 +148,15 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         // that we weren't partial filled).
         if (swapTokenBalanceBefore - _swapToken.balanceOf(address(this)) != swapTokenAmount) revert LeftoverSrcTokens();
 
+        emit SwapBeforeBridge(
+            EXCHANGE,
+            address(_swapToken),
+            address(_acrossInputToken),
+            swapTokenAmount,
+            returnAmount,
+            depositData.outputToken,
+            depositData.outputAmount
+        );
         // Deposit the swapped tokens into Across and bridge them using remainder of input params.
         _acrossInputToken.safeIncreaseAllowance(address(SPOKE_POOL), returnAmount);
         SPOKE_POOL.depositV3(

--- a/storage-layouts/Arbitrum_SpokePool.json
+++ b/storage-layouts/Arbitrum_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -223,11 +223,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -263,7 +263,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -310,13 +310,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -324,7 +324,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -332,7 +332,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Arbitrum_SpokePool.sol:Arbitrum_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Base_SpokePool.json
+++ b/storage-layouts/Base_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -247,11 +247,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -287,7 +287,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -334,13 +334,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -356,7 +356,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Base_SpokePool.sol:Base_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Ethereum_SpokePool.json
+++ b/storage-layouts/Ethereum_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -201,7 +201,7 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 44462,
+      "astId": 44496,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -209,7 +209,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 42660,
+      "astId": 42694,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "_owner",
       "offset": 0,
@@ -217,7 +217,7 @@
       "type": "t_address"
     },
     {
-      "astId": 42780,
+      "astId": 42814,
       "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -271,7 +271,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -311,13 +311,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -325,7 +325,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -333,7 +333,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Ethereum_SpokePool.sol:Ethereum_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Linea_SpokePool.json
+++ b/storage-layouts/Linea_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -206,7 +206,7 @@
       "label": "l2MessageService",
       "offset": 0,
       "slot": "3162",
-      "type": "t_contract(IMessageService)11741"
+      "type": "t_contract(IMessageService)11775"
     },
     {
       "astId": 2844,
@@ -214,7 +214,7 @@
       "label": "l2TokenBridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ITokenBridge)11753"
+      "type": "t_contract(ITokenBridge)11787"
     },
     {
       "astId": 2848,
@@ -222,7 +222,7 @@
       "label": "l2UsdcBridge",
       "offset": 0,
       "slot": "3164",
-      "type": "t_contract(IUSDCBridge)11767"
+      "type": "t_contract(IUSDCBridge)11801"
     }
   ],
   "types": {
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -271,22 +271,22 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(IMessageService)11741": {
+    "t_contract(IMessageService)11775": {
       "encoding": "inplace",
       "label": "contract IMessageService",
       "numberOfBytes": "20"
     },
-    "t_contract(ITokenBridge)11753": {
+    "t_contract(ITokenBridge)11787": {
       "encoding": "inplace",
       "label": "contract ITokenBridge",
       "numberOfBytes": "20"
     },
-    "t_contract(IUSDCBridge)11767": {
+    "t_contract(IUSDCBridge)11801": {
       "encoding": "inplace",
       "label": "contract IUSDCBridge",
       "numberOfBytes": "20"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -326,13 +326,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -340,7 +340,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Linea_SpokePool.sol:Linea_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Optimism_SpokePool.json
+++ b/storage-layouts/Optimism_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -247,11 +247,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -287,7 +287,7 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -334,13 +334,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -348,7 +348,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -356,7 +356,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Optimism_SpokePool.sol:Optimism_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/Polygon_SpokePool.json
+++ b/storage-layouts/Polygon_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -231,11 +231,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -276,7 +276,7 @@
       "label": "contract PolygonTokenBridger",
       "numberOfBytes": "20"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
@@ -316,13 +316,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -330,7 +330,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -338,7 +338,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/Polygon_SpokePool.sol:Polygon_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,

--- a/storage-layouts/ZkSync_SpokePool.json
+++ b/storage-layouts/ZkSync_SpokePool.json
@@ -1,7 +1,7 @@
 {
   "storage": [
     {
-      "astId": 43208,
+      "astId": 43242,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initialized",
       "offset": 0,
@@ -9,7 +9,7 @@
       "type": "t_uint8"
     },
     {
-      "astId": 43211,
+      "astId": 43245,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_initializing",
       "offset": 1,
@@ -17,7 +17,7 @@
       "type": "t_bool"
     },
     {
-      "astId": 43190,
+      "astId": 43224,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -25,7 +25,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43506,
+      "astId": 43540,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -33,7 +33,7 @@
       "type": "t_array(t_uint256)50_storage"
     },
     {
-      "astId": 43522,
+      "astId": 43556,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_status",
       "offset": 0,
@@ -41,7 +41,7 @@
       "type": "t_uint256"
     },
     {
-      "astId": 43591,
+      "astId": 43625,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -49,7 +49,7 @@
       "type": "t_array(t_uint256)49_storage"
     },
     {
-      "astId": 15923,
+      "astId": 15957,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -57,7 +57,7 @@
       "type": "t_array(t_uint256)1000_storage"
     },
     {
-      "astId": 15728,
+      "astId": 15762,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_NAME",
       "offset": 0,
@@ -65,7 +65,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15730,
+      "astId": 15764,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "_HASHED_VERSION",
       "offset": 0,
@@ -73,7 +73,7 @@
       "type": "t_bytes32"
     },
     {
-      "astId": 15829,
+      "astId": 15863,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "__gap",
       "offset": 0,
@@ -102,7 +102,7 @@
       "label": "DEPRECATED_wrappedNativeToken",
       "offset": 0,
       "slot": "2155",
-      "type": "t_contract(WETH9Interface)11825"
+      "type": "t_contract(WETH9Interface)11859"
     },
     {
       "astId": 5492,
@@ -142,7 +142,7 @@
       "label": "rootBundles",
       "offset": 0,
       "slot": "2156",
-      "type": "t_array(t_struct(RootBundle)12102_storage)dyn_storage"
+      "type": "t_array(t_struct(RootBundle)12136_storage)dyn_storage"
     },
     {
       "astId": 5508,
@@ -201,7 +201,7 @@
       "type": "t_array(t_uint256)999_storage"
     },
     {
-      "astId": 8123,
+      "astId": 8157,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "l2Eth",
       "offset": 0,
@@ -209,12 +209,12 @@
       "type": "t_address"
     },
     {
-      "astId": 8126,
+      "astId": 8160,
       "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
       "label": "zkErc20Bridge",
       "offset": 0,
       "slot": "3163",
-      "type": "t_contract(ZkBridgeLike)8112"
+      "type": "t_contract(ZkBridgeLike)8146"
     }
   ],
   "types": {
@@ -223,11 +223,11 @@
       "label": "address",
       "numberOfBytes": "20"
     },
-    "t_array(t_struct(RootBundle)12102_storage)dyn_storage": {
+    "t_array(t_struct(RootBundle)12136_storage)dyn_storage": {
       "encoding": "dynamic_array",
       "label": "struct SpokePoolInterface.RootBundle[]",
       "numberOfBytes": "32",
-      "base": "t_struct(RootBundle)12102_storage"
+      "base": "t_struct(RootBundle)12136_storage"
     },
     "t_array(t_uint256)1000_storage": {
       "encoding": "inplace",
@@ -263,12 +263,12 @@
       "label": "bytes32",
       "numberOfBytes": "32"
     },
-    "t_contract(WETH9Interface)11825": {
+    "t_contract(WETH9Interface)11859": {
       "encoding": "inplace",
       "label": "contract WETH9Interface",
       "numberOfBytes": "20"
     },
-    "t_contract(ZkBridgeLike)8112": {
+    "t_contract(ZkBridgeLike)8146": {
       "encoding": "inplace",
       "label": "contract ZkBridgeLike",
       "numberOfBytes": "20"
@@ -308,13 +308,13 @@
       "numberOfBytes": "32",
       "value": "t_uint256"
     },
-    "t_struct(RootBundle)12102_storage": {
+    "t_struct(RootBundle)12136_storage": {
       "encoding": "inplace",
       "label": "struct SpokePoolInterface.RootBundle",
       "numberOfBytes": "96",
       "members": [
         {
-          "astId": 12095,
+          "astId": 12129,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "slowRelayRoot",
           "offset": 0,
@@ -322,7 +322,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12097,
+          "astId": 12131,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "relayerRefundRoot",
           "offset": 0,
@@ -330,7 +330,7 @@
           "type": "t_bytes32"
         },
         {
-          "astId": 12101,
+          "astId": 12135,
           "contract": "contracts/ZkSync_SpokePool.sol:ZkSync_SpokePool",
           "label": "claimedBitmap",
           "offset": 0,


### PR DESCRIPTION
This will be important to track for frontends to determine when a non-supported token is swapped into a supported token via this contract before submitting an Across Bridge
