### PR TITLE
fix(SwapAndBridge): increase allowance of correct token

### DIFF
--- a/contracts/SwapAndBridge.sol
+++ b/contracts/SwapAndBridge.sol
@@ -98,7 +98,7 @@ abstract contract SwapAndBridgeBase is Lockable, MultiCaller {
         uint256 srcBalanceBefore = _swapToken.balanceOf(address(this));
         uint256 dstBalanceBefore = _acrossInputToken.balanceOf(address(this));
 
-        _acrossInputToken.safeIncreaseAllowance(EXCHANGE, swapTokenAmount);
+        _swapToken.safeIncreaseAllowance(EXCHANGE, swapTokenAmount);
         // solhint-disable-next-line avoid-low-level-calls
         (bool success, bytes memory result) = EXCHANGE.call(routerCalldata);
         require(success, string(result));


### PR DESCRIPTION
We need to increase the allowance of the `_swapToken` instead of `_acrossInputToken` before executing the swap.

Example success tx https://polygonscan.com/tx/0xbde4fe5e4844294e85b0f5e17af75e409deb6a006f508abf9e7127df5a4cf389