### PR TITLE
fix(test): include cctp relevant param in mock

### DIFF
--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -19,7 +19,7 @@ contract MockSpokePool is SpokePool, MockV2SpokePoolInterface, OwnableUpgradeabl
 
     uint256 public constant SLOW_FILL_MAX_TOKENS_TO_SEND = 1e40;
 
-    address public constant cctpTokenMessenger = Address(0);
+    address public constant cctpTokenMessenger = address(0);
 
     bytes32 public constant UPDATE_DEPOSIT_DETAILS_HASH =
         keccak256(

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -19,6 +19,8 @@ contract MockSpokePool is SpokePool, MockV2SpokePoolInterface, OwnableUpgradeabl
 
     uint256 public constant SLOW_FILL_MAX_TOKENS_TO_SEND = 1e40;
 
+    address public constant cctpTokenMessenger = Address(0);
+
     bytes32 public constant UPDATE_DEPOSIT_DETAILS_HASH =
         keccak256(
             "UpdateDepositDetails(uint32 depositId,uint256 originChainId,int64 updatedRelayerFeePct,address updatedRecipient,bytes updatedMessage)"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
This is causing some failures in relayer tests where we reference the mock spoke pool.